### PR TITLE
boj 11660 구간 합 구하기 5

### DIFF
--- a/dp/11660.py
+++ b/dp/11660.py
@@ -1,0 +1,15 @@
+import sys
+
+N, M = map(int, sys.stdin.readline().split())
+N = N + 1
+dp = [[0 for i in range(N)] for i in range(N)]
+for i in range(1, N):
+    dp[i] = list(map(int, ("0 " + sys.stdin.readline()).split()))
+
+for i in range(1, N):
+    for j in range(1, N):
+        dp[i][j] += (dp[i - 1][j] + dp[i][j - 1] - dp[i - 1][j - 1])
+
+for i in range(0, M):
+    sx, sy, ex, ey = map(int, sys.stdin.readline().split())
+    print(dp[ex][ey] - dp[ex][sy - 1] - dp[sx - 1][ey] + dp[sx - 1][sy - 1])


### PR DESCRIPTION
## 알고리즘 분류
dp, prefix sum

## 풀이 방법
1. `dp[i][j] = dp[i][j] + dp[i - 1][j] + dp[i][j - 1] - dp[i - 1][j - 1]` 식으로 누적합을 구한다.
2. `dp[ex][ey] - dp[ex][sy - 1] - dp[sx - 1][ey] + dp[sx - 1][sy - 1]` 식으로 `(x1, y1) ~ (x2, y2)`의 합을 출력한다.
